### PR TITLE
Remove unnecessary mz dependency

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,10 +2,11 @@
 
 const compressible = require('compressible')
 const toArray = require('stream-to-array')
-const compress = require('mz/zlib').gzip
 const isJSON = require('koa-is-json')
 const Bluebird = require('bluebird')
 const bytes = require('bytes')
+
+const compress = Bluebird.promisify(require('zlib').gzip)
 
 // methods we cache
 const methods = {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,6 @@
     "bytes": "^2.1.0",
     "compressible": "^2.0.0",
     "koa-is-json": "^1.0.0",
-    "mz": "^2.0.0",
     "stream-to-array": "^2.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
`gzip` from `mz/zlib` module is basically the same thing as

```js
Bluebird.promisify(require('zlib').gzip)
```

So, why do we need `mz` if we already have `bluebird`?