### PR TITLE
Types conversion

### DIFF
--- a/index.js
+++ b/index.js
@@ -48,7 +48,7 @@ module.exports = function (options) {
     }
 
     if (obj.gzip && this.request.acceptsEncodings('gzip', 'identity') === 'gzip') {
-      this.response.body = obj.gzip
+      this.response.body = new Buffer(obj.gzip)
       this.response.set('Content-Encoding', 'gzip')
     } else {
       this.response.body = obj.body


### PR DESCRIPTION
Most external cache stores (i.e. memcached) use JSON serialisation/deserialisation to store JS objects.

But JSON doesn't have `Buffer`s, so sending gzipped data to such store will result in its corruption.

However, we could easily cover this case with an explicit types conversion.

This solution won't allow us to automatically deserialize binary bodies (cached streams and buffers), so user will still have to ensure that his cache store can handle buffers before using them, but at least we will cover most cases.

**N.B.** There is absolutely no need to deserialize Dates, because `koa` is smart enough to handle it.