### PR TITLE
Support deflate

### DIFF
--- a/index.js
+++ b/index.js
@@ -53,7 +53,7 @@ module.exports = function (options) {
     }
 
     let encoding = this.acceptsEncodings('gzip', 'deflate', 'identity')
-    if (obj[encoding] && encoding !== 'identity') {
+    if (obj[encoding] && encoding && encoding !== 'identity') {
       this.response.body = new Buffer(obj[encoding])
       this.response.set('Content-Encoding', encoding)
     } else {
@@ -114,7 +114,7 @@ module.exports = function (options) {
         obj[method] = encodingMethods[method](body)
       }
       let encoding = this.acceptsEncodings('gzip', 'deflate', 'identity')
-      if (!fresh && encoding !== 'identity') {
+      if (!fresh && encoding && encoding !== 'identity') {
         this.response.body = yield obj[encoding]
         this.response.set('Content-Encoding', encoding)
       }


### PR DESCRIPTION
Most compression middlewares, including [koa-compress], support both `gzip` and `deflate`.

Shouldn't `koa-cash` support it as well?

Though, there are few Cons in supporting it:

 * we'll have to store more data
 * we'll need a little bit more complex compression code to pre-fill all supported encodings while returning only one of them

Any thoughts here?

 [koa-compress]: https://github.com/koajs/compress