### PR TITLE
fix missing content-type bug

### DIFF
--- a/index.js
+++ b/index.js
@@ -93,7 +93,7 @@ module.exports = function (options) {
     if ((this.response.get('Content-Encoding') || 'identity') !== 'identity') {
       throw new Error('Place koa-cache below any compression middleware.')
     }
-    
+
     const obj = {
       body,
       type: this.response.get('Content-Type') || null,
@@ -103,7 +103,7 @@ module.exports = function (options) {
 
     const fresh = this.request.fresh
     if (fresh) this.response.status = 304
-    
+
     if (compressible(obj.type) && this.response.length >= threshold) {
       obj.gzip = yield compress(body)
       if (!fresh && this.request.acceptsEncodings('gzip', 'identity') === 'gzip') {

--- a/index.js
+++ b/index.js
@@ -93,10 +93,7 @@ module.exports = function (options) {
     if ((this.response.get('Content-Encoding') || 'identity') !== 'identity') {
       throw new Error('Place koa-cache below any compression middleware.')
     }
-
-    const fresh = this.request.fresh
-    if (fresh) this.response.status = 304
-
+    
     const obj = {
       body,
       type: this.response.get('Content-Type') || null,
@@ -104,6 +101,9 @@ module.exports = function (options) {
       etag: this.response.get('etag') || null
     }
 
+    const fresh = this.request.fresh
+    if (fresh) this.response.status = 304
+    
     if (compressible(obj.type) && this.response.length >= threshold) {
       obj.gzip = yield compress(body)
       if (!fresh && this.request.acceptsEncodings('gzip', 'identity') === 'gzip') {


### PR DESCRIPTION
setting response.status to 304 removes the 'content-type' header as a side effect (see https://github.com/koajs/koa/blob/0b1b49cb8aa8da28f84c94f5eec82f19f1a764c7/test/response/status.js#L120)

When the first request of a path that is 'fresh', the browser that makes the request will not suffer an issue, but a subsequent request from another browser (who doesn't have a cached result) will get a cached result without the content type.

The fix simply delays setting of response.status until after extracting the content type.