### PR TITLE
Use util.promisify shim instead of Bluebird.promisify

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,7 +6,7 @@ const isJSON = require('koa-is-json')
 const Bluebird = require('bluebird')
 const bytes = require('bytes')
 
-const compress = Bluebird.promisify(require('zlib').gzip)
+const compress = require('util.promisify')(require('zlib').gzip)
 
 // methods we cache
 const methods = {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "bytes": "^2.1.0",
     "compressible": "^2.0.0",
     "koa-is-json": "^1.0.0",
-    "stream-to-array": "^2.0.0"
+    "stream-to-array": "^2.0.0",
+    "util.promisify": "^1.0.0"
   },
   "devDependencies": {
     "istanbul": "^0.4.2",


### PR DESCRIPTION
It's a fairly tiny change, though I like that `util.promisify` is a shim that behaves the same as the method added in Node 8, and it lets us rely on Bluebird less. In the future if this package only targets Node 8+, we can replace `require('util.promisify')` with `require('util').promisify`.

This does half of #53 (the other half is dropping `Bluebird.coroutine` which I haven't fixed yet).