### PR TITLE
feat: add X-Cached-Response header behind option

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,10 @@ Minimum byte size to compress response bodies. Default `1kb`.
 
 If a truthy value is passed, then compression will be enabled.  This value is `false` by default.
 
+#### `setCachedHeader`
+
+If a truthy value is passed, then `X-Cached-Response` header will be set as `HIT` when response is served from the cache.  This value is `false` by default.
+
 #### `hash()`
 
 A hashing function. By default, it's:

--- a/index.js
+++ b/index.js
@@ -17,7 +17,7 @@ const methods = {
 };
 
 module.exports = function(options) {
-  options = options || { compression: false };
+  options = options || { compression: false, setCachedHeader: false };
 
   const hash =
     options.hash ||
@@ -53,6 +53,7 @@ module.exports = function(options) {
     this.response.type = obj.type;
     if (obj.lastModified) this.response.lastModified = obj.lastModified;
     if (obj.etag) this.response.etag = obj.etag;
+    if (options.setCachedHeader) this.response.set('X-Cached-Response', 'HIT');
     if (this.request.fresh) {
       this.response.status = 304;
       return true;

--- a/test/when-cached.js
+++ b/test/when-cached.js
@@ -44,7 +44,7 @@ test.cb('when cached when the method is GET it should serve from cache', t => {
   const app = createApp(c);
   app.use(async function(ctx) {
     if (await ctx.cashed()) return;
-    throw new Error('wtf');
+    throw new Error('oops');
   });
 
   request(app.listen())
@@ -62,7 +62,7 @@ test.cb(
     const app = createApp(c, { setCachedHeader: true });
     app.use(async function(ctx) {
       if (await ctx.cashed()) return;
-      throw new Error('wtf');
+      throw new Error('oops');
     });
 
     request(app.listen())
@@ -81,7 +81,7 @@ test.cb(
   t => {
     const app = createApp(c);
     app.use(async function(ctx) {
-      if (await ctx.cashed()) throw new Error('wtf');
+      if (await ctx.cashed()) throw new Error('oops');
       ctx.body = 'lol';
     });
 
@@ -95,7 +95,7 @@ test.cb('when cached when the response is fresh it should 304', t => {
   const app = createApp(c);
   app.use(async function(ctx) {
     if (await ctx.cashed()) return;
-    throw new Error('wtf');
+    throw new Error('oops');
   });
 
   request(app.listen())


### PR DESCRIPTION
Add `setCachedHeader` option that, when `true`, sets a `X-Cached-Response` header set to `HIT` when response is served from cache.